### PR TITLE
optional S0 header, hence string to regex matching

### DIFF
--- a/fact_helper_file/mime/custom_mime_encoding
+++ b/fact_helper_file/mime/custom_mime_encoding
@@ -6,11 +6,7 @@
 
 # Motorola S-Record
 0 	string   S
->1   string   0
->1   string   1
->1   string   2
->1   string   3
->2  regex  [0-9A-F]{8,}$  Motorola S-Record; binary data in text format
+>1  regex  [0-3][0-9A-F]{8,}$  Motorola S-Record; binary data in text format
 !:mime  firmware/srecord
 
 # Tektronik HEX file format

--- a/fact_helper_file/mime/custom_mime_encoding
+++ b/fact_helper_file/mime/custom_mime_encoding
@@ -5,7 +5,11 @@
 !:mime	firmware/intel-hex
 
 # Motorola S-Record
-0 	regex   S[0-3]
+0 	string   S
+>1   string   0
+>1   string   1
+>1   string   2
+>1   string   3
 >2  regex  [0-9A-F]{8,}$  Motorola S-Record; binary data in text format
 !:mime  firmware/srecord
 

--- a/fact_helper_file/mime/custom_mime_encoding
+++ b/fact_helper_file/mime/custom_mime_encoding
@@ -5,8 +5,8 @@
 !:mime	firmware/intel-hex
 
 # Motorola S-Record
-0 	string	S0
->2   regex  [0-9A-F]{8,}$  Motorola S-Record; binary data in text format
+0 	regex   S[0-3]
+>2  regex  [0-9A-F]{8,}$  Motorola S-Record; binary data in text format
 !:mime  firmware/srecord
 
 # Tektronik HEX file format


### PR DESCRIPTION
Srecords S0 header seems to be optional. So we need to switch from a strict S0 string matching to a more relaxed regex that first checks for S[0-3] which is either a header or data field.