### PR TITLE
bugfix: ar archive mime should not match debian archives

### DIFF
--- a/fact_helper_file/mime/custom_mime_archives
+++ b/fact_helper_file/mime/custom_mime_archives
@@ -139,7 +139,9 @@
 !:mime	application/x-shar
 
 # ar archive
-0	string		=!<arch>\n		current ar archive
+# we don't want to match .deb archives here and negative lookahead is not allowed
+# this should be equivalent to '!<arch>\n(?!deb)'
+0   regex   =!<arch>\n([^d]..|.[^e].|..[^b]|$)  current ar archive
 !:mime	application/x-archive
-0	string		=<ar>		System V Release 1 ar archive
+0   string  =<ar>		System V Release 1 ar archive
 !:mime	application/x-archive


### PR DESCRIPTION
the new ar archive definition was erroneously matching Debian package archives (.deb) which led to the MIME being `application/x-archive`. This in turn resulted in the file is not being correctly unpacked by the extractor.

This PR introduces a regex for `application/x-archive` which excludes Debian packages.