### PR TITLE
Add MIME type for RTOS based Draytek firmware images

### DIFF
--- a/fact_helper_file/mime/custom_mime_firmware_containers
+++ b/fact_helper_file/mime/custom_mime_firmware_containers
@@ -750,3 +750,7 @@
 >8	ubelong+0x120	x		{size:%d}
 >12	ubelong		x		data CRC: 0x%08x,
 >16	string		x		key id: %.4s)
+
+# Draytek Firmware
+9       string  DkmfaaryTedecz  Draytek Firmware Container
+!:mime firmware/draytek

--- a/fact_helper_file/mime/custom_mime_firmware_containers
+++ b/fact_helper_file/mime/custom_mime_firmware_containers
@@ -752,5 +752,5 @@
 >16	string		x		key id: %.4s)
 
 # Draytek Firmware
-9       string  DkmfaaryTedecz  Draytek Firmware Container
-!:mime firmware/draytek
+9       string  DkmfaaryTedecz  Draytek RTOS Firmware Container
+!:mime firmware/draytek-rtos

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fact_helper_file"
-version = "0.2.16"
+version = "0.2.17"
 authors = [
     {name = "Johannes vom Dorp"}
 ]


### PR DESCRIPTION
Add MIME type for Real Time OS based Draytek firmware images.
The magic was guessed by comparing images that [draytek-arsenal](https://github.com/infobyte/draytek-arsenal) was able to extract.
Although there were neither false positives nor false negatives within the dataset of Draytek firmware update images I own, it would be nice to test this MIME type on a bigger dataset for possible false positives.